### PR TITLE
Update instruction message after create-yoga on npx

### DIFF
--- a/packages/cli/create/utils.ts
+++ b/packages/cli/create/utils.ts
@@ -49,7 +49,7 @@ export const createAppAction = ({
             color: 'yellow' as const,
           }
         : {
-            message: `cd ${chalk.magenta(`${path}`)} && ${chalk.magenta(`npm run start`)}`,
+            message: `cd ${chalk.magenta(`${path}`)} && ${chalk.magenta(`npm run build`)} && ${chalk.magenta(`npm run start`)}`,
             color: 'yellow' as const,
           },
     ];


### PR DESCRIPTION
currently after running 
```
```
you will receive an instruction like
```
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Starter GraphQL Axolotl Server - GraphQL Yoga example created.
To run it, type:
cd forum && npm run start
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
but after running `npm run start` you will receive the following error message 
```
npm run start                                                                                  ✔  study-analysis-service 3.12.6   00:49:36

> beerpub-yoga@0.8.7 start
> node lib/index.js

node:internal/modules/cjs/loader:1228
  throw err;
  ^

Error: Cannot find module '/Users/rhb/work/train/graphql/graphql_best_practices_mine/chapter08/forum/lib/index.js'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1225:15)
    at Module._load (node:internal/modules/cjs/loader:1051:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:174:12)
    at node:internal/main/run_main_module:28:49 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}

Node.js v20.18.0
```
simply because the `lib` directory is not there, hence you need to run `npm build` before `npm start`. So I've updated the message to be like
```
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Starter GraphQL Axolotl Server - GraphQL Yoga example created.
To run it, type:
cd forum &&  npm run build && npm run start
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```